### PR TITLE
v1.1.0: BREAKING: The logic for `version_prerelease: true` allows non-prerelease now.

### DIFF
--- a/.github/workflows/package-enforcement.yml
+++ b/.github/workflows/package-enforcement.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.0.2
+        uses: kylorhall/enforce-package-dependency-version@v1.1.0
         with:
           package: "@actions/core"
           range: "^1.2.0"
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.0.2
+        uses: kylorhall/enforce-package-dependency-version@v1.1.0
         with:
           package: "typescript"
           range: "^4.0.0"
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.0.2
+        uses: kylorhall/enforce-package-dependency-version@v1.1.0
         with:
           package: "@types/jest"
           range: ">=26"

--- a/README.md
+++ b/README.md
@@ -33,15 +33,26 @@ jobs:
           echo resolved_version: ${{ steps.enforce.outputs.resolved_version }}
 ```
 
-# Valid Inputs
+# Inputs
 
 - **`package`** _[required]_
   - The name of the dependency to check.
 - **`directory`**
   - Directory where your `package.json` can be found.
-  - Defaults to to `env.GITHUB_WORKSPACE`.
+  - `default=env.GITHUB_WORKSPACE`
 - **`range`** _[required]_
   - A semver range, eg. '^1.0.0', '1.0.0', '>=1.x', etc..
+- **`version_prerelease`**
+  - An optional prerelease target.
+  - `default=false`
+  - `false` requires there is no prerelease.
+  - `true` allows a prerelease—but it is not required! `1.2.3-prerelease` and `1.2.3` are both valid
+  - `'prerelease'` means it must match that prerelease.
+  - `'prerelease.#'` means it must match that prerelease and identifier.
+- **`allow_multiple_versions`**
+  - Whether or not we allow multiple versions to be resolved, eg. you may have Typescript at `^4.2.0` in your codebase, but another package points to `3.x`.
+  - `false` means this should only ever resolve to a single version (and that should match our range)
+  - `true` allows all versions… NOTE: we only look at the first resolved version, assuming this is your version.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.0.2
+        uses: kylorhall/enforce-package-dependency-version@v1.1.0
         with:
           package: "typescript"
           range: ">=4.2.0"

--- a/__tests__/enforce.jest.ts
+++ b/__tests__/enforce.jest.ts
@@ -64,14 +64,17 @@ describe("enforce", () => {
       }
     );
 
-    test("failing: when prerelease=true (not a prerelease)", () => {
-      expect(() =>
-        enforceVersion({ ...config, version_prerelease: true })
-      ).toThrowError("⚠️ Expected a prerelease on '7.3.5', got none.");
-    });
+    test.each([true, false])(
+      "passing: when version_prerelease=%p (not a prerelease)",
+      (prerelease) => {
+        expect(() =>
+          enforceVersion({ ...config, version_prerelease: prerelease })
+        ).not.toThrow();
+      }
+    );
 
     test.each(["one", "two"])(
-      "failing: when prerelease=%p (not a prerelease)",
+      "failing: when version_prerelease=%p (not a prerelease)",
       (prerelease) => {
         expect(() =>
           enforceVersion({ ...config, version_prerelease: prerelease })

--- a/__tests__/run.jest.ts
+++ b/__tests__/run.jest.ts
@@ -128,6 +128,29 @@ describe("run", () => {
     expect(setOutputSpy).toHaveBeenCalledWith("resolved_version", "4.2.4"); // what is in `yarn.lock`
   });
 
+  test.each([true, false])(
+    "passing scenario: a non-prerelease with version_prerelease=%p",
+    (prerelease) => {
+      overrideInputs({
+        package: "typescript",
+        range: "^4.2.0", // the value we're testing for…may not 100% match `package.json` or `yarn.lock`
+        version_prerelease: prerelease,
+      });
+
+      // NOTE: This runs on load, this is how you do that…
+      // jest.resetModules();
+      jest.isolateModules(() => {
+        require("../src/run");
+      });
+
+      expect(setFailedSpy).not.toHaveBeenCalled();
+
+      expect(setOutputSpy).toHaveBeenCalledTimes(2);
+      expect(setOutputSpy).toHaveBeenCalledWith("target_version", "^4.0.0"); // what is in `package.json`
+      expect(setOutputSpy).toHaveBeenCalledWith("resolved_version", "4.2.4"); // what is in `yarn.lock`
+    }
+  );
+
   test("passing scenario: yallist (in dependencies) with allow_multiple_versions=true", () => {
     overrideInputs({
       package: "yallist",

--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,17 @@ inputs:
     description: >-
       An optional prerelease target.  Defaults to false.
        - `false` requires there is no prerelease.
-       - `true` includes prerelease in the range.
+       - `true` allows a prerelease—but it is not required! `1.2.3-prerelease` and `1.2.3` are both valid
        - `'prerelease'` means it must match that prerelease.
        - `'prerelease.#'` means it must match that prerelease and identifier.
+    default: false
     required: false
   allow_multiple_versions:
     description: >-
-      Whether or not we allow multiple versions to be resolved.  Defaults to false.
+      Whether or not we allow multiple versions to be resolved, eg. you may have Typescript at `^4.2.0` in your codebase, but another package points to `3.x`.
        - `false` means this should only ever resolve to a single version (and that should match our range)
-       - `true` allows all versions…we only look at the first resolved version
+       - `true` allows all versions… NOTE: we only look at the first resolved version, assuming this is your version.
+    default: false
     required: false
 
 outputs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enforce-package-dependency-version",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Allows us to enforce a specific package dependency version in a `package.json` file.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/enforce.ts
+++ b/src/enforce.ts
@@ -26,11 +26,7 @@ export function enforceVersion(config: Config = getConfig()): void {
   }
 
   if (config.version_prerelease === true) {
-    if (parsedVersion.prerelease && !parsedVersion.prerelease.length) {
-      throw new Error(
-        `⚠️ Expected a prerelease on '${parsedVersion.version}', got none.`
-      );
-    }
+    // NOTE: In this case, we do not care!
   } else if (config.version_prerelease === false) {
     if (parsedVersion.prerelease && parsedVersion.prerelease.length) {
       throw new Error(


### PR DESCRIPTION
- It may be a valid scenario to have a prerelease on either `1.2.3` or `1.2.3-prerelease.1`, we should allow both in that scenario (not strictly only allow `1.2.3-prerelease.1`.
- If you want strict, use `version_prerelease: 'prerelease'` or `version_prerelease: 'prerelease.1'` in that scenario.