### PR TITLE
Run CI against self rather than a fixed version.

### DIFF
--- a/.github/workflows/package-enforcement.yml
+++ b/.github/workflows/package-enforcement.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.1.2
+        uses: ./
         with:
           package: "@actions/core"
           range: "^1.5.0"
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.1.2
+        uses: ./
         with:
           package: "typescript"
           range: "^4.4.0"
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: kylorhall/enforce-package-dependency-version@v1.1.2
+        uses: ./
         with:
           package: "@types/jest"
           range: ">=26"

--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ yarn jest:tdd
 #### Prepare Build
 
 1. Deicde on a semver, eg. `1.2.3`.
-2. Bump this version in `package.json` file—just for the sake of it.
-3. Bump this version in `.github/workflows/package-enforcement.yml` file.
-4. Bump this version in `README.md` file.
-5. Run `yarn build` and commit that `dist/index.js` change.
-6. Version bumps should go via a PR and be merged into _master_ before releasing.
+2. Bump this version in `package.json` file.
+3. Bump this version in `README.md` example.
+4. Run `yarn build` and commit that `dist/index.js` change.
+5. Version bumps should go via a PR and be merged into _master_ before releasing.
 
 #### Create the Release
 


### PR DESCRIPTION
A fixed version breaks when we're releasing a new version–it hasn't been released yet.